### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ dbdata:
   image: andreagrandi/postgresql:9.3
   volumes:
     - /var/lib/postgresql
-  command: true
+  command: /bin/true
 
 db:
   image: andreagrandi/postgresql:9.3


### PR DESCRIPTION
With docker compose 1.7.1+, the command: true is being seen as a boolean. By fully qualifying the command (/bin/true) docker-compose is happy.  See https://github.com/docker/compose/issues/1638
